### PR TITLE
Zoom problems in ie

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "zoom"
   ],
   "contributors": [
-    "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)"
+    "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+    "Martin Bednorz <m.s.bednorz@gmail.com>"
   ],
   "author": "jillix <contact@jillix.com>",
   "license": "MIT",

--- a/src/svg.pan-zoom.js
+++ b/src/svg.pan-zoom.js
@@ -217,7 +217,7 @@
               , oY = rP.y
               ;
 
-            e.deltaY = e.deltaY || e.wheelDeltaY;
+            e.deltaY = e.deltaY || e.wheelDeltaY || -e.wheelDelta;
 
             // Compute the new scale
             var d = opt_options.zoomSpeed * e.deltaY / 1000


### PR DESCRIPTION
Fixed #15. Zoom is now working under IE 11 and 10 (I didn't test 9 or 8).
